### PR TITLE
feat: support repository.homepage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
@@ -50,7 +50,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
+        uses: github/codeql-action/init@47b3d888fe66b639e431abf22ebca059152f1eea # v3.24.5
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,7 +63,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
+        uses: github/codeql-action/autobuild@47b3d888fe66b639e431abf22ebca059152f1eea # v3.24.5
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -76,6 +76,6 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
+        uses: github/codeql-action/analyze@47b3d888fe66b639e431abf22ebca059152f1eea # v3.24.5
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,13 @@ jobs:
       fail-fast: false
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@eb238b55efaa70779f274895e782ed17c84f2895 # v2.6.1
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
@@ -64,7 +64,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: SARIF file
           path: results.sarif
@@ -72,6 +72,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@407ffafae6a767df3e0230c3df91b6443ae8df75 # v2.22.8
+        uses: github/codeql-action/upload-sarif@47b3d888fe66b639e431abf22ebca059152f1eea # v3.24.5
         with:
           sarif_file: results.sarif

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "homepage": "https://github.com/NodeSecure/ossf-scorecard-sdk#readme",
   "devDependencies": {
     "@nodesecure/eslint-config": "^1.9.0",
-    "@npm/types": "^1.0.2",
     "@slimio/is": "^2.0.0",
     "@types/node": "^20.11.20",
     "c8": "^9.1.0",
@@ -55,7 +54,7 @@
   },
   "dependencies": {
     "@myunisoft/httpie": "^4.0.0",
-    "@nodesecure/npm-registry-sdk": "^2.1.0",
+    "@nodesecure/npm-registry-sdk": "^2.1.1",
     "dotenv": "^16.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,21 +41,21 @@
   },
   "homepage": "https://github.com/NodeSecure/ossf-scorecard-sdk#readme",
   "devDependencies": {
-    "@nodesecure/eslint-config": "^1.8.0",
+    "@nodesecure/eslint-config": "^1.9.0",
     "@npm/types": "^1.0.2",
     "@slimio/is": "^2.0.0",
-    "@types/node": "^20.10.0",
-    "c8": "^8.0.1",
-    "eslint": "^8.54.0",
+    "@types/node": "^20.11.20",
+    "c8": "^9.1.0",
+    "eslint": "^8.57.0",
     "glob": "^10.3.10",
     "is-svg": "^5.0.0",
     "registry-url": "^6.0.1",
-    "tsx": "^4.5.0",
-    "typescript": "^5.3.2"
+    "tsx": "^4.7.1",
+    "typescript": "^5.3.3"
   },
   "dependencies": {
-    "@myunisoft/httpie": "^2.0.3",
-    "@nodesecure/npm-registry-sdk": "^1.6.1",
-    "dotenv": "^16.3.1"
+    "@myunisoft/httpie": "^4.0.0",
+    "@nodesecure/npm-registry-sdk": "^2.1.0",
+    "dotenv": "^16.4.5"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ config();
 // Import Third-party Dependencies
 import { get } from "@myunisoft/httpie";
 import { packument } from "@nodesecure/npm-registry-sdk";
-import type { PackumentVersion } from "@npm/types";
 
 // Import Internal Dependencies
 import { repositoryFromUrl } from "./utils/repositoryFromUrl.js";
@@ -45,9 +44,6 @@ export type ScorecardResult = {
   checks: ScorecardCheck[];
 };
 
-// TODO: https://github.com/NodeSecure/npm-registry-sdk/pull/125
-type FixedPackumentVersion = PackumentVersion & { homepage: string };
-
 export interface IResultOptions {
   /**
    * @description VCS platform. eg. github.com
@@ -75,7 +71,7 @@ async function getNpmRepository(repository: string): Promise<string> {
     throw new Error("Cannot find the latest version of the given repository");
   }
 
-  const packageVersion = data.versions[latestVersion] as FixedPackumentVersion;
+  const packageVersion = data.versions[latestVersion];
   const homepage = packageVersion.homepage || null;
   const repo = packageVersion.repository;
   const repoUrl = typeof repo === "string" ? repo : repo?.url;

--- a/test/result.spec.ts
+++ b/test/result.spec.ts
@@ -88,7 +88,7 @@ describe("#result() UT", () => {
     await assert.rejects(
       scorecard.result(expectedRepository),
       {
-        name: "Error",
+        name: "HttpieOnHttpError",
         message: "Not Found"
       }
     );
@@ -138,7 +138,7 @@ describe("#result() FT", () => {
       resolveOnVersionControl: false,
       resolveOnNpmRegistry: false
     }), {
-      name: "Error",
+      name: "HttpieOnHttpError",
       message: "Not Found"
     });
   });


### PR DESCRIPTION
Theses changes add support for `repository.homepage`.

When using `await scorecard.result("@topcli/prompts", { resolveOnVersionControl: false });` it fails because the package does not have the repository field set in package.json. However, the homepage is set.

Note: this is also what we do in scanner so we are ISO: https://github.com/NodeSecure/scanner/blob/master/src/utils/getLinks.js#L34

Note: I'll add (in a next PR) a `npmVersion` option that allow to fetch a specific package version instead of the latest-release, it will allow to functional test theses changes with the `@topcli/prompts` package, i'll lock the version to 1.9.0 then if we add the repository field the test does not break.

Draft until https://github.com/NodeSecure/npm-registry-sdk/pull/125