### PR TITLE
feat: npmPackageVersion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ export interface IResultOptions {
    * @description The version of the npm package (when `resolveOnNpmRegistry` only) to retrieve the scorecard for.
    * @default "latest"
    */
-  version?: string;
+  npmPackageVersion?: string;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ export interface IResultOptions {
    * @default true
    */
   resolveOnVersionControl?: boolean;
+  /**
+   * @description The version of the npm package (when `resolveOnNpmRegistry` only) to retrieve the scorecard for.
+   * @default "latest"
+   */
+  version?: string;
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "homepage": "https://github.com/NodeSecure/ossf-scorecard-sdk#readme",
   "devDependencies": {
+    "@matteo.collina/tspl": "^0.1.1",
     "@nodesecure/eslint-config": "^1.9.0",
     "@slimio/is": "^2.0.0",
     "@types/node": "^20.11.20",

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export interface IResultOptions {
    * @description The version of the npm package (when `resolveOnNpmRegistry` only) to retrieve the scorecard for.
    * @default "latest"
    */
-  version?: string;
+  npmPackageVersion?: string;
 }
 
 async function getNpmRepository(repository: string, version: string): Promise<string> {
@@ -114,7 +114,7 @@ export async function result(
     platform = kDefaultPlatform,
     resolveOnNpmRegistry = true,
     resolveOnVersionControl = true,
-    version = "latest"
+    npmPackageVersion = "latest"
   } = options;
   const [owner, repo] = repository.replace("@", "").split("/");
 
@@ -140,7 +140,7 @@ export async function result(
       }
 
       try {
-        formattedRepository = await getNpmRepository(repository, version);
+        formattedRepository = await getNpmRepository(repository, npmPackageVersion);
       }
       catch (error) {
         throw new Error(`Invalid repository, cannot find it on ${platformName} or NPM registry`, {
@@ -151,7 +151,7 @@ export async function result(
   }
   else if (resolveOnNpmRegistry && !resolveOnVersionControl) {
     try {
-      formattedRepository = await getNpmRepository(repository, version);
+      formattedRepository = await getNpmRepository(repository, npmPackageVersion);
     }
     catch (error) {
       throw new Error(`Invalid repository, cannot find it on NPM registry`, {

--- a/test/result.spec.ts
+++ b/test/result.spec.ts
@@ -223,7 +223,10 @@ describe("#result() FT", () => {
   });
 
   it("Should return a specific npm package ScorecardResult that does not have the repository set but has a homepage", async() => {
-    const result = await scorecard.result(`@topcli/prompts`, { resolveOnVersionControl: false, version: "1.9.0" });
+    const result = await scorecard.result(`@topcli/prompts`, {
+      resolveOnVersionControl: false,
+      npmPackageVersion: "1.9.0"
+    });
 
     assert.equal(is.plainObject(result), true);
     assert.equal(result.repo.name, `github.com/TopCli/prompts`);
@@ -240,7 +243,7 @@ describe("#result() FT", () => {
     try {
       await scorecard.result(`@topcli/prompts`, {
         resolveOnVersionControl: false,
-        version: "99999.0.0"
+        npmPackageVersion: "99999.0.0"
       });
     }
     catch (error) {

--- a/test/result.spec.ts
+++ b/test/result.spec.ts
@@ -6,6 +6,7 @@ import { after, afterEach, before, beforeEach, describe, it } from "node:test";
 import { MockAgent, getGlobalDispatcher, setGlobalDispatcher, Interceptable } from "@myunisoft/httpie";
 import is from "@slimio/is";
 import * as npmRegistrySdk from "@nodesecure/npm-registry-sdk";
+import { tspl, type Plan } from "@matteo.collina/tspl";
 
 // Import Internal Dependencies
 import * as scorecard from "../src/index.js";
@@ -188,14 +189,14 @@ describe("#result() FT", () => {
   });
 
   it("should throw when given a package and npm resolve is falsy", async() => {
-    assert.rejects(async() => scorecard.result("@unknown-package/for-sure", { resolveOnNpmRegistry: false }), {
+    await assert.rejects(async() => scorecard.result("@unknown-package/for-sure", { resolveOnNpmRegistry: false }), {
       name: "Error",
       message: "Invalid repository, cannot find it on github"
     });
   });
 
   it("should throw when given a package and npm resolve is falsy (GitLab)", async() => {
-    assert.rejects(async() => scorecard.result("@unknown-package/for-sure", {
+    await assert.rejects(async() => scorecard.result("@unknown-package/for-sure", {
       platform: "gitlab.com",
       resolveOnNpmRegistry: false
     }), {
@@ -205,20 +206,48 @@ describe("#result() FT", () => {
   });
 
   it("should throw when given an unknown npm package", async() => {
-    assert.rejects(async() => await scorecard.result("@unknown-package/for-sure", { resolveOnNpmRegistry: true }), {
+    await assert.rejects(async() => await scorecard.result("@unknown-package/for-sure", { resolveOnNpmRegistry: true }), {
       name: "Error",
       message: "Invalid repository, cannot find it on github or NPM registry"
     });
   });
 
   it("should throw when given an unknown npm package (GitLab)", async() => {
-    assert.rejects(async() => await scorecard.result("@unknown-package/for-sure", {
+    await assert.rejects(async() => await scorecard.result("@unknown-package/for-sure", {
       platform: "gitlab.com",
       resolveOnNpmRegistry: true
     }), {
       name: "Error",
       message: "Invalid repository, cannot find it on gitlab or NPM registry"
     });
+  });
+
+  it("Should return a specific npm package ScorecardResult that does not have the repository set but has a homepage", async() => {
+    const result = await scorecard.result(`@topcli/prompts`, { resolveOnVersionControl: false, version: "1.9.0" });
+
+    assert.equal(is.plainObject(result), true);
+    assert.equal(result.repo.name, `github.com/TopCli/prompts`);
+    assert.deepStrictEqual(
+      Object.keys(result).sort(),
+      ["date", "repo", "scorecard", "score", "checks"].sort()
+    );
+  });
+
+  it("Should throws when the given package version does not exists", async(testContext) => {
+    const tsplAssert: Plan = tspl(testContext, { plan: 3 });
+
+    // We cannot use assert.rejects to test Error.cause
+    try {
+      await scorecard.result(`@topcli/prompts`, {
+        resolveOnVersionControl: false,
+        version: "99999.0.0"
+      });
+    }
+    catch (error) {
+      tsplAssert.strictEqual(error.name, "Error");
+      tsplAssert.strictEqual(error.message, "Invalid repository, cannot find it on NPM registry");
+      tsplAssert.match(error.cause.message, /^Cannot find the version '99999.0.0' of the given repository/);
+    }
   });
 });
 


### PR DESCRIPTION
This PR add a new `version` option that allow to fetch the Scorecard result for a specific version (when given a npm package only)