### PR TITLE
fix(npm): fallback to homepage instead of repo url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ async function getNpmRepository(repository: string, version: string): Promise<st
   const repo = packageVersion.repository;
   const repoUrl = typeof repo === "string" ? repo : repo?.url;
 
-  return repositoryFromUrl(homepage ?? repoUrl ?? "");
+  return repositoryFromUrl(repoUrl ?? homepage ?? "");
 }
 
 async function retrieveRepositoryOnGithub(owner: string, repo: string): Promise<string> {


### PR DESCRIPTION
When a package has a non-vcs homepage, we prefer fallback to the homepage and use repo url first.

Example: fastify homepage is `fastify.dev`