### PR TITLE
chore: remove unused devDependencies after Node.js 22 upgrade

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
       fail-fast: false
     steps:
       - name: Harden Runner

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build",
-    "test": "glob -c \"tsx --test\" \"./test/**/*.spec.ts\"",
-    "coverage": "c8 -r html npm test",
+    "test": "node --test",
+    "coverage": "node --test-coverage",
     "lint": "eslint src/*.ts"
   },
   "repository": {
@@ -41,17 +41,11 @@
   },
   "homepage": "https://github.com/NodeSecure/ossf-scorecard-sdk#readme",
   "devDependencies": {
-    "@matteo.collina/tspl": "^0.2.0",
-    "@nodesecure/eslint-config": "^1.9.0",
     "@openally/config.eslint": "^2.0.0",
     "@openally/config.typescript": "^1.0.3",
     "@slimio/is": "^2.0.0",
     "@types/node": "^22.2.0",
-    "c8": "^10.1.2",
-    "eslint": "^9.9.0",
-    "glob": "^11.0.0",
     "is-svg": "^6.0.0",
-    "registry-url": "^7.0.0",
     "tsx": "^4.7.1",
     "typescript": "^5.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Closes #121

This PR removes unnecessary dev dependencies that became obsolete with the upgrade to Node.js v22:

- Removed: 
- - @matteo.collina/tspl
- - glob 
- - c8, eslint 
- - @nodesecure/eslint-config 
- - registry-url
- Updated `engines.node` to `>=22`
- ---------
- Removed Node.js 20.x from CI _(after feedback)_